### PR TITLE
Manual specification of syllable requirements for poem env

### DIFF
--- a/llfbench/envs/poem/formal_poems.py
+++ b/llfbench/envs/poem/formal_poems.py
@@ -333,7 +333,7 @@ class LineSyllableConstrainedPoem(Haiku):
 
         self._seed = self.seed(seed)
 
-    def reset(self, syllable_req=None, *kwargs):
+    def reset(self, syllable_req=None, **kwargs):
         if 'seed' in kwargs:
             self._seed = self.seed(kwargs['seed'])
 

--- a/llfbench/envs/poem/formal_poems.py
+++ b/llfbench/envs/poem/formal_poems.py
@@ -333,7 +333,7 @@ class LineSyllableConstrainedPoem(Haiku):
 
         self._seed = self.seed(seed)
 
-    def reset(self, **kwargs):
+    def reset(self, syllable_req=None, *kwargs):
         if 'seed' in kwargs:
             self._seed = self.seed(kwargs['seed'])
 
@@ -343,9 +343,10 @@ class LineSyllableConstrainedPoem(Haiku):
         # https://www.writing.upenn.edu/~afilreis/88/meter.html
         syllable_sample_space = [5, 7, 8, 9, 10, 17]
 
-        syllable_req = []
-        for _ in range(number_of_lines):
-            syllable_req.append(self._np_random.choice(syllable_sample_space))
+        if syllable_req is None:
+            syllable_req = []
+            for _ in range(number_of_lines):
+                syllable_req.append(self._np_random.choice(syllable_sample_space))
 
         self.syllable_req_str = [str(i) for i in syllable_req]
         self.syllable_req = syllable_req
@@ -375,13 +376,13 @@ class SyllableConstrainedPoem(PoemUtil, gym.Env):
 
         self.docstring = self.assignment
 
-    def reset(self, **kwargs):
+    def reset(self, syllable=None, **kwargs):
         if 'seed' in kwargs:
             self._seed = self.seed(kwargs['seed'])
 
         # https://www.writing.upenn.edu/~afilreis/88/meter.html
         syllable_sample_space = [5, 7, 8, 9, 10, 17]
-        syllable = self._np_random.choice(syllable_sample_space)
+        syllable = self._np_random.choice(syllable_sample_space) if syllable is None else syllable
         self.syllable = syllable
         self.assignment = f"Can you produce a short poem where each line has {syllable} syllables?"
 


### PR DESCRIPTION
Added manual specification of syllable requirements in reset() for poem env as it seemed to be a useful feature.  This allows for an agent to learn over multiple episodes in the same environment, or benchmark agents on specific instances of this environment. 